### PR TITLE
fix: Avoid duplicate injection of tailwind global.css

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,5 +6,8 @@ import tailwind from '@astrojs/tailwind';
 // https://astro.build/config
 export default defineConfig({
     site: 'https://ovidius-astro-theme.netlify.app',
-    integrations: [mdx(), sitemap(), tailwind()]
+    integrations: [mdx(), sitemap(), tailwind({
+        // Disable injecting a basic `base.css` import on every page.
+        config: { applyBaseStyles: false }
+    })]
 });

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -73,5 +73,5 @@ module.exports = {
             })
         }
     },
-    plugins: [require('@tailwindcss/typography', { applyBaseStyles: false })]
+    plugins: [require('@tailwindcss/typography')]
 };

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -73,5 +73,5 @@ module.exports = {
             })
         }
     },
-    plugins: [require('@tailwindcss/typography')]
+    plugins: [require('@tailwindcss/typography', { applyBaseStyles: false })]
 };


### PR DESCRIPTION
Astro and tailwind will automatically generate a "base.css" and inject it to page, making it a double import, first the base.css and then your global.css - making all of tailwind's css coming in twice.

The solution is to deactivate the automatic injection whenever you have manual stuff like you have with the primary color in the global.css

See https://docs.astro.build/en/guides/integrations-guide/tailwind/